### PR TITLE
Redirect immediately

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="1;url=https://w3c.github.io/screen-wake-lock/" />
+<meta http-equiv="refresh" content="0;url=https://w3c.github.io/screen-wake-lock/" />


### PR DESCRIPTION
Or is there any reason to wait 1 second before redirecting users?

FWIW, I'm proposing this change because this pause actually makes the automatic extraction of IDL through Reffy fail (see https://github.com/tidoust/reffy/issues/303): Reffy misses the redirection because it considers the navigation to be over if nothing happens after 500ms ([`networkidle0` setting](https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-pagegotourl-options) in Puppeteer).
